### PR TITLE
Add ingress for dev and sqa

### DIFF
--- a/deploy/k8s/overlays/jax-cluster-dev-10--dev/ingress.yaml
+++ b/deploy/k8s/overlays/jax-cluster-dev-10--dev/ingress.yaml
@@ -11,3 +11,18 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: "https://auth.jax-cluster-dev-10.jax.org/oauth2/start?rd=https://$http_host$escaped_request_uri"
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - "geneweaver-dev.jax.org"
+      secretName: geneweaver-dev-jax-org-tls
+  rules:
+  - host: "geneweaver-dev.jax.org"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/api"
+        backend:
+          service:
+            name: geneweaver-api
+            port:
+              number: 8000

--- a/deploy/k8s/overlays/jax-cluster-dev-10--dev/kustomization.yaml
+++ b/deploy/k8s/overlays/jax-cluster-dev-10--dev/kustomization.yaml
@@ -6,6 +6,10 @@ namespace: dev
 bases:
 - ../../base
 
+# NOTE: When applying production ingress, replace this with a patch
+resources:
+  - ingress.yaml
+
 #patchesStrategicMerge:
 #  - configmap.yaml
 #  - ingress.yaml

--- a/deploy/k8s/overlays/jax-cluster-dev-10--sqa/ingress.yaml
+++ b/deploy/k8s/overlays/jax-cluster-dev-10--sqa/ingress.yaml
@@ -11,3 +11,18 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: "https://auth.jax-cluster-dev-10.jax.org/oauth2/start?rd=https://$http_host$escaped_request_uri"
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - "geneweaver-sqa.jax.org"
+      secretName: geneweaver-sqa-jax-org-tls
+  rules:
+  - host: "geneweaver-sqa.jax.org"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/api"
+        backend:
+          service:
+            name: geneweaver-api
+            port:
+              number: 8000

--- a/deploy/k8s/overlays/jax-cluster-dev-10--sqa/kustomization.yaml
+++ b/deploy/k8s/overlays/jax-cluster-dev-10--sqa/kustomization.yaml
@@ -6,6 +6,10 @@ namespace: sqa
 bases:
 - ../../base
 
+# NOTE: When applying production ingress, replace this with a patch
+resources:
+  - ingress.yaml
+
 #patchesStrategicMerge:
 #  - configmap.yaml
 #  - ingress.yaml


### PR DESCRIPTION
This PR adds DNS and ingress for the geneweaver API in the CS Cluster for dev and sqa instances.