### PR TITLE
Update dev ingress to use real cert, bump version for deployment to sqa

### DIFF
--- a/deploy/k8s/overlays/jax-cluster-dev-10--dev/ingress.yaml
+++ b/deploy/k8s/overlays/jax-cluster-dev-10--dev/ingress.yaml
@@ -5,8 +5,8 @@ metadata:
   annotations:
     # NOTE: When deploying a new instance, make sure to use the staging issuer first
     # so that you don't hit the rate limit for the production issuer.
-    cert-manager.io/cluster-issuer: "letsencrypt-staging"
-    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # cert-manager.io/cluster-issuer: "letsencrypt-staging"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/auth-url: "https://auth.jax-cluster-dev-10.jax.org/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://auth.jax-cluster-dev-10.jax.org/oauth2/start?rd=https://$http_host$escaped_request_uri"
 spec:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-api"
-version = "0.0.1a3"
+version = "0.0.1a4"
 description = "description"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 packages = [


### PR DESCRIPTION
The deployment to geneweaver-dev.jax.org went smoothly, and the staging certificate was provisioned. This PR requests a production certificate for the dev instance, and bumps the project version number to trigger a deploy to SQA.

There will be one more PR for this ticket after we validate that a staging certificate is provisioned to SQA.