### PR TITLE
G3 131: Fixing null name bug in register user, bumping version (Follow Up)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-api"
-version = "0.0.1a9"
+version = "0.0.1a10"
 description = "description"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 packages = [

--- a/src/geneweaver/api/dependencies.py
+++ b/src/geneweaver/api/dependencies.py
@@ -54,6 +54,8 @@ async def full_user(
         elif db_user.email_exists(cursor, user.email):
             user.id = db_user.link_user_id_with_sso_id(cursor, user.id, user.sso_id)
         else:
+            if not user.name:
+                user.name = user.email
             user.id = db_user.create_sso_user(
                 cursor, user.name, user.email, user.sso_id
             )


### PR DESCRIPTION
This change deals with the case when no user name is available. 

In that case, the first name will default to the email, and the last name will be left empty. This matches the current logic on Geneweaver.org.