### PR TITLE
Step one, deploy v0.0.1 to test certs and deployment in stage and prod

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-api"
-version = "0.0.1a13"
+version = "0.0.1"
 description = "description"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 packages = [


### PR DESCRIPTION
This is step 1 in our initial release process ([GW-145](https://jacksonlaboratory.atlassian.net/browse/G3-145?atlOrigin=eyJpIjoiZjUwYzQ0MDgxYTRjNGNlYjlmNmM4ZDU0M2Q2NThmYjUiLCJwIjoiaiJ9))
1. Bump version number to 0.0.1.
2. Verify lets encrypt staging certificates.
3. Replace staging certificates with prod certificates and bump version number to 0.1.0 to indicate the first release.