### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-api"
-version = "0.2.0a7"
+version = "0.2.0"
 description = "The Geneweaver API"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"


### PR DESCRIPTION
This PR will release version 0.2.0 of the Geneweaver API.