### PR TITLE
Allowing non-authenticated requests on the genesets endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-api"
-version = "0.6.0a0"
+version = "0.6.0a1"
 description = "The Geneweaver API"
 authors = [
     "Alexander Berger <alexander.berger@jax.org>",

--- a/src/geneweaver/api/controller/genesets.py
+++ b/src/geneweaver/api/controller/genesets.py
@@ -4,7 +4,7 @@ import json
 import os
 import time
 from tempfile import TemporaryDirectory
-from typing import Optional
+from typing import Optional, Set
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security
 from fastapi.responses import FileResponse
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/genesets", tags=["genesets"])
 
 @router.get("")
 def get_visible_genesets(
-    user: UserInternal = Security(deps.full_user),
+    user: UserInternal = Security(deps.optional_full_user),
     cursor: Optional[deps.Cursor] = Depends(deps.cursor),
     gs_id: Annotated[
         Optional[int],
@@ -38,7 +38,7 @@ def get_visible_genesets(
     only_my_genesets: Annotated[
         Optional[bool], Query(description=api_message.ONLY_MY_GS)
     ] = False,
-    curation_tier: Optional[GenesetTier] = None,
+    curation_tier: Annotated[Optional[Set[GenesetTier]], Query()] = None,
     species: Optional[Species] = None,
     name: Annotated[Optional[str], Query(description=api_message.NAME)] = None,
     abbreviation: Annotated[

--- a/src/geneweaver/api/core/exceptions.py
+++ b/src/geneweaver/api/core/exceptions.py
@@ -25,3 +25,11 @@ class Auth0UnauthorizedException(HTTPException):
     def __init__(self, **kwargs) -> None:  # noqa: ANN003
         """Initialize the exception."""
         super().__init__(403, **kwargs)
+
+
+class UnauthorizedException(HTTPException):
+    """Exception for unauthorized requests."""
+
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
+        """Initialize the exception."""
+        super().__init__(403, **kwargs)

--- a/src/geneweaver/api/core/security.py
+++ b/src/geneweaver/api/core/security.py
@@ -138,7 +138,7 @@ class Auth0:
         ),
     ) -> UserInternal:
         """Get the user from the token, raise an exception if not found."""
-        return await self.get_user(security_scopes, creds, True)
+        return await self.get_user(security_scopes, creds, True, disallow_public=True)
 
     async def get_user(  # noqa: C901
         self,
@@ -147,7 +147,7 @@ class Auth0:
             Auth0HTTPBearer(auto_error=False)
         ),
         auto_error_auth: Optional[bool] = True,
-        disallow_public: Optional[bool] = True,
+        disallow_public: Optional[bool] = False,
     ) -> Optional[UserInternal]:
         """Get the user from the token, don't error if not found."""
         auto_error_auth = (


### PR DESCRIPTION
This PR allows for public requests to the Genesets endpoint by returning only Tier1-4 datasets when an unauthenticated request is made.

This also allows for all requests to specify some combination of Geneset tiers, instead of just a single one.