### PR TITLE
G3-348: Switching to thejacksonlaboratory Auth0 tenant. 

### DIFF
--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: geneweaver-config
 data:
-  AUTH_CLIENT_ID: "T7bj6wlmtVcAN2O6kzDRwPVFyIj4UQNs"
+  AUTH_CLIENT_ID: "aE6dpT04mGlvPeUXl4RYGSnCjvHEuawd"

--- a/deploy/k8s/overlays/jax-cluster-prod-10--prod/configmap.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--prod/configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: geneweaver-config
 data:
-  AUTH_CLIENT_ID: "oVm9omUtLBpVyL7YfJA8gp3hHaHwyVt8"
+  AUTH_CLIENT_ID: "C0PrH88Pmjmba9ObVKaIRUITQeiA1Q4D"

--- a/deploy/k8s/overlays/jax-cluster-prod-10--stage/configmap.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--stage/configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: geneweaver-config
 data:
-  AUTH_CLIENT_ID: "oVm9omUtLBpVyL7YfJA8gp3hHaHwyVt8"
+  AUTH_CLIENT_ID: "C0PrH88Pmjmba9ObVKaIRUITQeiA1Q4D"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-api"
-version = "0.8.0a3"
+version = "0.8.0a4"
 description = "The Geneweaver API"
 authors = [
     "Alexander Berger <alexander.berger@jax.org>",

--- a/src/geneweaver/api/controller/api.py
+++ b/src/geneweaver/api/controller/api.py
@@ -24,7 +24,10 @@ app = FastAPI(
     redoc_url=f"{settings.API_PREFIX}/redoc",
     openapi_url=f"{settings.API_PREFIX}/openapi.json",
     swagger_ui_oauth2_redirect_url=f"{settings.API_PREFIX}/docs/oauth2-redirect",
-    swagger_ui_init_oauth={"clientId": settings.AUTH_CLIENT_ID},
+    swagger_ui_init_oauth={
+        "clientId": settings.AUTH_CLIENT_ID,
+        "scopes": list(settings.AUTH_SCOPES.keys()),
+    },
     lifespan=deps.lifespan,
 )
 

--- a/src/geneweaver/api/core/config_class.py
+++ b/src/geneweaver/api/core/config_class.py
@@ -35,15 +35,15 @@ class GeneweaverAPIConfig(BaseSettings):
             )
         return self
 
-    AUTH_DOMAIN: str = "geneweaver.auth0.com"
-    AUTH_AUDIENCE: str = "https://api.geneweaver.org"
+    AUTH_DOMAIN: str = "thejacksonlaboratory.auth0.com"
+    AUTH_AUDIENCE: str = "https://cube.jax.org"
     AUTH_ALGORITHMS: List[str] = ["RS256"]
-    AUTH_EMAIL_NAMESPACE: str = AUTH_AUDIENCE
+    AUTH_EMAIL_CLAIM: str = "email"
     AUTH_SCOPES: dict = {
         "openid profile email": "read",
     }
     JWT_PERMISSION_PREFIX: str = "approle"
-    AUTH_CLIENT_ID: str = "T7bj6wlmtVcAN2O6kzDRwPVFyIj4UQNs"
+    AUTH_CLIENT_ID: str = "aE6dpT04mGlvPeUXl4RYGSnCjvHEuawd"
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/src/geneweaver/api/core/security.py
+++ b/src/geneweaver/api/core/security.py
@@ -69,6 +69,7 @@ class Auth0:
         auto_error: bool = True,
         scope_auto_error: bool = True,
         email_auto_error: bool = False,
+        email_claim: str = "email",
         auth0user_model: Type[UserInternal] = UserInternal,
     ) -> None:
         """Initialize the Auth0 class."""
@@ -80,6 +81,7 @@ class Auth0:
         self.auto_error = auto_error
         self.scope_auto_error = scope_auto_error
         self.email_auto_error = email_auto_error
+        self.email_claim = email_claim
 
         self.auth0_user_model = auth0user_model
 
@@ -277,7 +279,7 @@ class Auth0:
         payload["auth_header"] = {"Authorization": f"Bearer {token}"}
 
     def _process_email(self, payload: dict) -> None:
-        payload["email"] = payload.pop(f"{self.audience}/claims/email")
+        payload["email"] = payload.pop(f"{self.audience}/{self.email_claim}")
 
         if payload["email"] is not None:
             payload["email"] = payload["email"].lower()

--- a/src/geneweaver/api/dependencies.py
+++ b/src/geneweaver/api/dependencies.py
@@ -19,6 +19,7 @@ auth = Auth0(
     domain=settings.AUTH_DOMAIN,
     api_audience=settings.AUTH_AUDIENCE,
     scopes=settings.AUTH_SCOPES,
+    email_claim=settings.AUTH_EMAIL_CLAIM,
     auto_error=False,
 )
 

--- a/tests/core/test_security.py
+++ b/tests/core/test_security.py
@@ -60,7 +60,7 @@ def create_test_token(mock_requests, claims=None):
     # claims
     if claims is None:
         to_encode = {
-            f"{test_audience}/claims/email": test_email,
+            f"{test_audience}/email": test_email,
             "iss": f"https://{test_domain}/",
             "aud": test_audience,
             "name": test_name,
@@ -247,7 +247,7 @@ async def test_invalid_claim(
     mock_jwt_unverified_header.return_value = private_key
 
     to_encode = {
-        f"{test_audience}/claims/email": test_email,
+        f"{test_audience}/email": test_email,
         "name": test_name,
         "scope": "openid profile email",
     }
@@ -277,7 +277,7 @@ async def test_missing_claim_email_error_claim(
     mock_jwt_unverified_header.return_value = private_key
 
     to_encode = {
-        f"{test_audience}/claims/email": None,
+        f"{test_audience}/email": None,
         "iss": f"https://{test_domain}/",
         "aud": test_audience,
         "name": test_name,


### PR DESCRIPTION
Updating API to use thejacksonlaboratory Auth0 client by default, and updating manifests to define the same.

Using swagger authentication will continue to work for Geneweaver users. 

Please **expect the following changes** to the login process:

1. You will to be asked to "Log in to The Jackson Laboratory to continue." 
2. You will see The Jackson Laboratory's logo on the login page, instead of the Geneweaver logo.

---

A note for users of the [geneweaver-client](https://github.com/TheJacksonLaboratory/geneweaver-client) library and CLI.

This will break the [geneweaver-client](https://github.com/TheJacksonLaboratory/geneweaver-client) authentication defaults, meaning 
⚠️ **you will not be able to log in without additional action.** ⚠️ 

To fix this, you will need to either:

1. Update the geneweaver-client library to version 0.10.0 or higher ([see this PR](https://github.com/TheJacksonLaboratory/geneweaver-client/pull/43)) , or
2. Set the following environment variables before running the gweave commands, and then re-authneticate
```
export AUTH_DOMAIN="thejacksonlaboratory.auth0.com"
export AUTH_CLIENT_ID="f8QZPcIrPIG6DIeWR2Rr3C8X5bzx8zBz"
gweaver beta auth login --reauth
```