### PR TITLE
G3-406: Adding CORS config to ingress definitions

### DIFF
--- a/deploy/k8s/overlays/jax-cluster-dev-10--dev/ingress.yaml
+++ b/deploy/k8s/overlays/jax-cluster-dev-10--dev/ingress.yaml
@@ -9,6 +9,15 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://auth.jax-cluster-dev-10.jax.org/oauth2/start?rd=https://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.jax.org, http://localhost:4200, http://localhost:8080"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      if ($request_method = "OPTIONS") {
+        return 202;
+      }
 spec:
   ingressClassName: nginx
   tls:

--- a/deploy/k8s/overlays/jax-cluster-dev-10--sqa/ingress.yaml
+++ b/deploy/k8s/overlays/jax-cluster-dev-10--sqa/ingress.yaml
@@ -9,6 +9,15 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://auth.jax-cluster-dev-10.jax.org/oauth2/start?rd=https://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.jax.org"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      if ($request_method = "OPTIONS") {
+        return 202;
+      }
 spec:
   ingressClassName: nginx
   tls:

--- a/deploy/k8s/overlays/jax-cluster-prod-10--prod/ingress.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--prod/ingress.yaml
@@ -7,6 +7,11 @@ metadata:
     # so that you don't hit the rate limit for the production issuer.
     # cert-manager.io/cluster-issuer: "letsencrypt-staging"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.jax.org"
 spec:
   ingressClassName: nginx
   tls:

--- a/deploy/k8s/overlays/jax-cluster-prod-10--prod/ingress.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--prod/ingress.yaml
@@ -30,7 +30,7 @@ spec:
             path: "/api"
             backend:
               service:
-                name: geneweaver-legacy
+                name: geneweaver-api
                 port:
                   number: 8000
     - host: "geneweaver.jax.org"
@@ -60,7 +60,7 @@ spec:
             path: "/api"
             backend:
               service:
-                name: geneweaver-legacy
+                name: geneweaver-api
                 port:
                   number: 8000
     - host: "classic.geneweaver.org"
@@ -70,6 +70,6 @@ spec:
             path: "/api"
             backend:
               service:
-                name: geneweaver-legacy
+                name: geneweaver-api
                 port:
                   number: 800

--- a/deploy/k8s/overlays/jax-cluster-prod-10--stage/ingress.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--stage/ingress.yaml
@@ -9,6 +9,15 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://auth.jax-cluster-prod-10.jax.org/oauth2/start?rd=https://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.jax.org"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      if ($request_method = "OPTIONS") {
+        return 202;
+      }
 spec:
   ingressClassName: nginx
   tls:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-api"
-version = "0.8.0"
+version = "0.8.1a0"
 description = "The Geneweaver API"
 authors = [
     "Alexander Berger <alexander.berger@jax.org>",


### PR DESCRIPTION
This PR adds CORS configuration to the ingress definition to allow for cross origin calls from *.jax.org domains. 